### PR TITLE
Fixed support for absolute pathnames in writing TAR files

### DIFF
--- a/archive.asd
+++ b/archive.asd
@@ -4,7 +4,7 @@
 (in-package :archive-system)
 
 (asdf:defsystem :archive
-  :version "0.8.1"
+  :version "0.8.2"
   :author "Nathan Froyd <froydnj@gmail.com>"
   :description "A package for reading and writing archive (tar, cpio, etc.) files."
   :depends-on (#+sbcl sb-posix trivial-gray-streams cl-fad)

--- a/archive.lisp
+++ b/archive.lisp
@@ -114,16 +114,20 @@ requirements about alignment."
     (values)))
 
 (defmethod write-entry-to-archive :after (archive (entry directory-entry-mixin)
-                                                  &key stream)
+                                          &key stream)
   (declare (ignore stream))
   (let ((prefix-length (length (pathname-directory
-                                *default-pathname-defaults*))))
+                                *default-pathname-defaults*)))
+        (dirname (name entry)))
     (fad:walk-directory
-     (name entry)
+     dirname
      (lambda (pathname)
-       (let* ((directory (cons :relative
-                               (nthcdr prefix-length
-                                       (pathname-directory pathname))))
+       (let* ((absolute? (and (not (string= "" dirname))
+                              (char= #\/ (char dirname 0))))
+              (directory (if absolute? (string-trim "/" dirname)
+                             (cons :relative
+                                   (nthcdr prefix-length
+                                           (pathname-directory pathname)))))
               (adjusted-pathname (make-pathname :directory directory
                                                 :name (pathname-name pathname)
                                                 :type (pathname-type pathname)))


### PR DESCRIPTION
Turns out my previous patch from 2010 only handled relative pathnames (it was reported to me by email).
So I've added support for absolute pathnames as well.

Had to do a merge with -Xtheirs to integrate the latest upstream changes, but github (or git?) doesn't quite understand that, that's why previous commits are also included into the "Pull request". 

Also I think it would be beneficial to add a regression test for this feature (and I'm willing to do that), but there's not test suite so far...
