### PR TITLE
Fix for *print-case* incongruous with readtable-case.

### DIFF
--- a/macros.lisp
+++ b/macros.lisp
@@ -3,9 +3,9 @@
 (in-package :archive)
 
 (defun extractor-function-name (entry-name field-name)
-  (intern (format nil "~A-READ-~A-FROM-BUFFER" entry-name field-name)))
+  (intern (with-standard-io-syntax (format nil "~A-READ-~A-FROM-BUFFER" entry-name field-name))))
 (defun injector-function-name (entry-name field-name)
-  (intern (format nil "~A-WRITE-~A-TO-BUFFER" entry-name field-name)))
+  (intern (with-standard-io-syntax (format nil "~A-WRITE-~A-TO-BUFFER" entry-name field-name))))
 
 (defmacro with-extracted-fields ((entry-class buffer offset &rest fields)
                                  &body body)
@@ -60,14 +60,13 @@
 (defmacro define-octet-header (class-name &rest field-defs)
   (let ((offset 0))                     ; could be integrated in the LOOP?
     (flet ((offset-constant-symbol (name)
-             (intern (format nil "+~A-~A-OFFSET+" class-name
-                             (string-upcase (symbol-name name)))))
+             (intern (with-standard-io-syntax
+                       (format nil "+~A-~A-OFFSET+" class-name name))))
            (length-constant-symbol (name)
-             (intern (format nil "+~A-~A-LENGTH+" class-name
-                             (string-upcase (symbol-name name)))))
+             (intern (with-standard-io-syntax
+                       (format nil "+~A-~A-LENGTH+" class-name name))))
            (keywordify-name (name)
-             (intern (string-upcase (symbol-name name))
-                     (find-package "KEYWORD"))))
+             (intern (symbol-name name) (find-package "KEYWORD"))))
       (loop for (name length kind) in field-defs
             collect `(defconstant ,(offset-constant-symbol name)
                       ,offset) into constant-defs
@@ -117,7 +116,7 @@
                         ,@constant-defs
                         ,@reader-defs
                         ,@writer-defs
-                        (defconstant ,(intern (format nil "+~A-LENGTH+" class-name)) ,offset)
+                        (defconstant ,(intern (with-standard-io-syntax (format nil "+~A-LENGTH+" class-name))) ,offset)
                         (defclass ,class-name ()
                           ,slot-definitions
                           (:default-initargs ,@default-initargs))))))))


### PR DESCRIPTION
When `*print-case*` does not match readtable-case, in particular when it is set to :downcase, `format` produces mixed case strings unsuitable for `intern`.
