### PR TITLE
Fix recursive adds

### DIFF
--- a/archive.lisp
+++ b/archive.lisp
@@ -117,15 +117,19 @@ requirements about alignment."
                                           &key stream)
   (declare (ignore stream))
   (let ((dirname (name entry)))
-    (fad:walk-directory
-     dirname
+    (mapc
      (lambda (pathname)
-       (let* ((absolute? (and (not (string= "" dirname))
-                              (char= #\/ (char dirname 0))))
-              (adjusted-pathname (if absolute? pathname
-                                     (fad:pathname-as-file (enough-namestring pathname))))
-              (entry (create-entry-from-pathname archive adjusted-pathname)))
-         (write-entry-to-archive archive entry))))))
+       (flet ((relative-pathname (pathname)
+                (if (fad:directory-pathname-p pathname)
+                    (fad:pathname-as-directory (enough-namestring pathname))
+                    (fad:pathname-as-file (enough-namestring pathname)))))
+         (let* ((absolute? (and (not (string= "" dirname))
+                                (char= #\/ (char dirname 0))))
+                (adjusted-pathname (if absolute? pathname
+                                       (relative-pathname pathname)))
+                (entry (create-entry-from-pathname archive adjusted-pathname)))
+           (write-entry-to-archive archive entry))))
+     (fad:list-directory dirname))))
 
 
 ;;; providing streamy access for an entry


### PR DESCRIPTION
This branch fixes two issues when adding a directory: the adjusted pathname for files found by walk-directory assumed the files existed under the top-level directory being added, and no entries were created for directories found recursively.

Fixing the latter issue meant switching from fad:walk-directory to fad:list-directory to prevent processing files multiple times -- the directory walk is now done by mutual recursion between write-entry-to-archive and write-entry-to-archive :after.

It wasn't completely clear whether you meant a directory add to be recursive, but I figured it was sensible since that's the default behavior of the tar utility. If you meant it to be non-recursive, just let me know and I'll see if I can fix it up.
