### PR TITLE
Fix error calling SB-POSIX:STAT on a file stream fd.

### DIFF
--- a/archive.lisp
+++ b/archive.lisp
@@ -50,7 +50,7 @@
   (let ((stream (archive-stream instance)))
     ;; Hopefully this is portable.
     (when (typep stream 'file-stream)
-      (let ((stat (stat #+sbcl (sb-impl::fd-stream-fd stream)
+      (let ((stat (stat #+sbcl (truename stream)
                         #+cmucl (system::stream-fd stream)
                         #+(and lispworks unix) (stream::os-file-handle-stream-file-handle stream))))
         (when (and stat (isreg (stat-mode stat)))


### PR DESCRIPTION
SBCL has an error on windows where calling
`(SB-POSIX:STAT (SB-SYS:FD-STREAM-FD <stream>))` yields an error
"The storage control block address is invalid. (9)". This is likely a bug
in SBCL, but it's easy to avoid here, by retrieving a pathname with
`(TRUENAME <stream>)` and passing that to STAT instead. This change allows
archive to successfully create tar files on my machine.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/froydnj/archive/16)

<!-- Reviewable:end -->
