### PR TITLE
Allow symbolic/hard links in a TAR file

### DIFF
--- a/tar.lisp
+++ b/tar.lisp
@@ -418,6 +418,8 @@
                (setf (linkname entry) real-link-name)
                entry))
             ((or (= (typeflag entry) +tar-regular-file+)
+                 (= (typeflag entry) +tar-hard-link+)
+                 (= (typeflag entry) +tar-symbolic-link+)
                  (= (typeflag entry) +tar-directory-file+))
              entry)
             ((= (typeflag entry) +posix-global-header+)
@@ -441,7 +443,9 @@
     (cond
       ((= (typeflag entry) +tar-directory-file+)
        (ensure-directories-exist name))
-      ((= (typeflag entry) +tar-regular-file+)
+      ((or (= (typeflag entry) +tar-regular-file+)
+           (= (typeflag entry) +tar-hard-link+)
+           (= (typeflag entry) +tar-symbolic-link+))
        (ensure-directories-exist name)
        (with-open-file (stream name :direction :output
                                :if-exists :supersede
@@ -482,6 +486,8 @@
                                            &key stream)
   (declare (ignore stream))
   (unless (member (typeflag entry) (list +tar-regular-file+
+                                         +tar-hard-link+
+                                         +tar-symbolic-link+
                                          +tar-directory-file+
                                          +gnutar-long-name+)
                   :test #'=)


### PR DESCRIPTION
Archive raises `ARCHIVE:UNHANDLED-READ-HEADER-ERROR` when extracting a tarball if it contains a symbolic link.

## Reproducible steps

1. `wget https://github.com/ndantam/sycamore/archive/master.tar.gz -O sycamore.tar.gz`
2. Start a REPL and execute the following:

```
(ql:quickload '(:archive :gzip-stream))
(gzip-stream:with-open-gzip-file (gzip #P"sycamore.tar.gz")
  (let ((archive (archive:open-archive 'archive:tar-archive gzip)))
    (archive:do-archive-entries (entry archive)
      (format t "~&~S~%" entry))))
```
3. Debugger invoked with `ARCHIVE:UNHANDLED-READ-HEADER-ERROR`.

NOTE: This problem is turned out at https://github.com/fukamachi/qlot/issues/45.